### PR TITLE
fix: fallback to redirect when popup closes

### DIFF
--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -92,8 +92,14 @@ export function AuthProvider({ children }) {
       
       // Handle specific Firebase auth errors
       if (error.code === 'auth/popup-closed-by-user') {
-        // Don't show error for this - user intentionally closed popup
-        console.log('User closed the sign-in popup');
+        if (typeof window !== 'undefined' && window.location.hostname !== 'localhost') {
+          try {
+            await signInWithRedirect(auth, googleProvider);
+            return 'redirect';
+          } catch (redirectError) {
+            console.error('Redirect sign-in failed:', redirectError);
+          }
+        }
         return 'popup-closed';
       } else if (error.code === 'auth/popup-blocked') {
         toast.error('Popup was blocked by your browser. Please allow popups and try again, or use the redirect option.');

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -3,6 +3,14 @@ import ReactDOM from 'react-dom/client'
 import App from './App'
 import './index.css'
 
+if (import.meta.env.PROD) {
+  const noop = () => {}
+  console.log = noop
+  console.info = noop
+  console.debug = noop
+  console.warn = noop
+}
+
 // Initialize lazy Firebase loading on user interaction
 import { initFirebaseOnInteraction } from './utils/lazyFirebase'
 

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -25,8 +25,8 @@ function Login() {
     if (result === true) {
       navigate('/cms/dashboard');
     } else if (result === 'popup-closed') {
-      // User closed popup intentionally - don't show error
-      setErrorMessage('');
+      setShowRedirectOption(true);
+      setErrorMessage('The sign-in popup was closed before completing. You can try the redirect method below.');
     } else if (result === 'popup-blocked') {
       setShowRedirectOption(true);
       setErrorMessage('Popup was blocked. You can try the redirect method below.');


### PR DESCRIPTION
## Summary
- use Google sign-in redirect if the popup closes unexpectedly
- show redirect option message when popup was closed
- suppress debug console output in production

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad49ddea44832c85b123d4e3b13a23